### PR TITLE
Add log crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["Alex Zywicki <alexander.zywicki@gmail.com>, and others...(tbd)"]
 edition = "2018"
 
 [dependencies]
+log = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate log;
+
 pub mod element;
 pub mod event;
 pub mod mouse;


### PR DESCRIPTION
A super easy first PR.

Add the `log` crate so we can use it during development, to see what's happening within `rtb-rs`